### PR TITLE
Support decoding optional values hyperbee skips (en/de)coding

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ function unionCompare (e1, e2) {
 function decodeEntry (diffEntry, keyEncoding, valueEncoding) {
   if (!diffEntry) return diffEntry
   if (keyEncoding) diffEntry.key = keyEncoding.decode(diffEntry.key)
-  if (valueEncoding) diffEntry.value = valueEncoding.decode(diffEntry.value)
+  if (valueEncoding && diffEntry.value !== null) diffEntry.value = valueEncoding.decode(diffEntry.value)
   return diffEntry
 }
 


### PR DESCRIPTION
The `value` in `bee.put(key, value)` is optional and is not encoded via the `valueEncoding` option when the node is appended. Because of this, `hyperbee-diff-stream` threw an error trying to decode a `null` assuming it was a buffer. A new check for `null` skips decoding allowing it to pass through.

For reference, here is where hyperbee currently skips decoding: https://github.com/holepunchto/hyperbee/blob/ba9b6cde9dcfd8c639769b4118593b3b8c269b31/index.js#L325